### PR TITLE
Add search optimizations for deeper analysis

### DIFF
--- a/src/bin/profile.rs
+++ b/src/bin/profile.rs
@@ -1,0 +1,112 @@
+use rust_chess::board::Board;
+use rust_chess::search::{minimax, minimax_no_quiescence, minimax_with_tt, iterative_deepening};
+use rust_chess::tt::TranspositionTable;
+use std::time::Instant;
+
+const SEB_FEN: &str = "r3k2r/p1ppqpb1/Bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPB1PPP/R3K2R b KQkq - 0 1";
+
+fn main() {
+    let mut b = Board::from_fen(SEB_FEN);
+
+    println!("=== Chess Engine Performance ===\n");
+
+    // Depth 4 without quiescence
+    println!("Depth 4 WITHOUT quiescence (no TT):");
+    let start = Instant::now();
+    let result = minimax_no_quiescence(4, &b).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Nodes: {}", result.nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+
+    // Depth 4 with quiescence
+    println!("\nDepth 4 WITH quiescence (no TT):");
+    let start = Instant::now();
+    let result = minimax(4, &b).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Main nodes: {}", result.nodes_searched);
+    println!("  Quiescent nodes: {}", result.quiescent_nodes_searched);
+    println!("  Total nodes: {}", result.nodes_searched + result.quiescent_nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+
+    // Depth 4 with TT
+    println!("\nDepth 4 WITH TT (64MB):");
+    let mut tt = TranspositionTable::new(64);
+    let start = Instant::now();
+    let result = minimax_with_tt(4, &mut b, &mut tt).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Main nodes: {}", result.nodes_searched);
+    println!("  Quiescent nodes: {}", result.quiescent_nodes_searched);
+    println!("  Total nodes: {}", result.nodes_searched + result.quiescent_nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+    println!("  {}", tt.info());
+
+    // Depth 5 with TT
+    println!("\nDepth 5 WITH TT (64MB):");
+    tt.clear();
+    let start = Instant::now();
+    let result = minimax_with_tt(5, &mut b, &mut tt).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Main nodes: {}", result.nodes_searched);
+    println!("  Quiescent nodes: {}", result.quiescent_nodes_searched);
+    println!("  Total nodes: {}", result.nodes_searched + result.quiescent_nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+    println!("  {}", tt.info());
+
+    // Depth 5 with iterative deepening
+    println!("\nDepth 5 ITERATIVE DEEPENING (64MB TT):");
+    tt.clear();
+    let start = Instant::now();
+    let result = iterative_deepening(5, &mut b, &mut tt).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Main nodes: {}", result.nodes_searched);
+    println!("  Quiescent nodes: {}", result.quiescent_nodes_searched);
+    println!("  Total nodes: {}", result.nodes_searched + result.quiescent_nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+    println!("  {}", tt.info());
+
+    // Depth 6 with iterative deepening
+    println!("\nDepth 6 ITERATIVE DEEPENING (64MB TT):");
+    tt.clear();
+    let start = Instant::now();
+    let result = iterative_deepening(6, &mut b, &mut tt).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Main nodes: {}", result.nodes_searched);
+    println!("  Quiescent nodes: {}", result.quiescent_nodes_searched);
+    println!("  Total nodes: {}", result.nodes_searched + result.quiescent_nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+    println!("  {}", tt.info());
+
+    // Depth 7 with iterative deepening
+    println!("\nDepth 7 ITERATIVE DEEPENING (64MB TT):");
+    tt.clear();
+    let start = Instant::now();
+    let result = iterative_deepening(7, &mut b, &mut tt).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Main nodes: {}", result.nodes_searched);
+    println!("  Quiescent nodes: {}", result.quiescent_nodes_searched);
+    println!("  Total nodes: {}", result.nodes_searched + result.quiescent_nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+    println!("  {}", tt.info());
+
+    // Depth 8 with iterative deepening
+    println!("\nDepth 8 ITERATIVE DEEPENING (64MB TT):");
+    tt.clear();
+    let start = Instant::now();
+    let result = iterative_deepening(8, &mut b, &mut tt).unwrap();
+    let elapsed = start.elapsed();
+    println!("  Time: {:?}", elapsed);
+    println!("  Main nodes: {}", result.nodes_searched);
+    println!("  Quiescent nodes: {}", result.quiescent_nodes_searched);
+    println!("  Total nodes: {}", result.nodes_searched + result.quiescent_nodes_searched);
+    println!("  Best move: {}", result.best_move.unwrap().to_algebraic());
+    println!("  {}", tt.info());
+
+    println!("\nDone!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod types;
+pub mod zobrist;
+pub mod tt;
 pub mod movegen;
 pub mod board;
 pub mod evaluate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use clap::Parser;
 use color_eyre::eyre::Result;
 
 mod types;
+mod zobrist;
+mod tt;
 mod board;
 mod book;
 mod evaluate;

--- a/src/tt.rs
+++ b/src/tt.rs
@@ -1,0 +1,283 @@
+use crate::types::Move;
+
+/// Transposition table entry flags
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TTFlag {
+    /// Exact score (PV node)
+    Exact,
+    /// Score is a lower bound (cut node - failed high)
+    LowerBound,
+    /// Score is an upper bound (all node - failed low)
+    UpperBound,
+}
+
+/// A single entry in the transposition table
+#[derive(Debug, Clone, Copy)]
+pub struct TTEntry {
+    /// Zobrist hash of the position
+    pub hash: u64,
+    /// Depth of the search when this entry was stored
+    pub depth: u8,
+    /// Score of the position
+    pub score: i32,
+    /// Type of node/bound
+    pub flag: TTFlag,
+    /// Best move found (for move ordering)
+    pub best_move: Option<Move>,
+}
+
+impl TTEntry {
+    pub fn empty() -> Self {
+        TTEntry {
+            hash: 0,
+            depth: 0,
+            score: 0,
+            flag: TTFlag::Exact,
+            best_move: None,
+        }
+    }
+}
+
+/// Transposition table for caching search results
+pub struct TranspositionTable {
+    /// Table entries (power of 2 size for fast modulo via bitmask)
+    entries: Vec<TTEntry>,
+    /// Bitmask for indexing (size - 1)
+    size_mask: usize,
+    /// Statistics
+    pub hits: u64,
+    pub stores: u64,
+    pub collisions: u64,
+}
+
+impl TranspositionTable {
+    /// Create a new transposition table with approximately `size_mb` megabytes of memory
+    pub fn new(size_mb: usize) -> Self {
+        let entry_size = std::mem::size_of::<TTEntry>();
+        let num_entries = (size_mb * 1024 * 1024) / entry_size;
+        // Round down to nearest power of 2
+        let num_entries = num_entries.next_power_of_two() >> 1;
+        let num_entries = num_entries.max(1024); // Minimum 1024 entries
+
+        let entries = vec![TTEntry::empty(); num_entries];
+        let size_mask = num_entries - 1;
+
+        TranspositionTable {
+            entries,
+            size_mask,
+            hits: 0,
+            stores: 0,
+            collisions: 0,
+        }
+    }
+
+    /// Get the index for a given hash
+    #[inline]
+    fn index(&self, hash: u64) -> usize {
+        (hash as usize) & self.size_mask
+    }
+
+    /// Probe the table for a position
+    /// Returns Some((score, best_move)) if we can use the cached result
+    pub fn probe(
+        &mut self,
+        hash: u64,
+        depth: u8,
+        alpha: i32,
+        beta: i32,
+    ) -> Option<(i32, Option<Move>)> {
+        let idx = self.index(hash);
+        let entry = &self.entries[idx];
+
+        // Check if this is the right position
+        if entry.hash != hash {
+            return None;
+        }
+
+        // Only use if searched to at least this depth
+        if entry.depth < depth {
+            return None;
+        }
+
+        self.hits += 1;
+
+        // Check if we can use the score based on the bound type
+        match entry.flag {
+            TTFlag::Exact => Some((entry.score, entry.best_move)),
+            TTFlag::LowerBound => {
+                if entry.score >= beta {
+                    Some((entry.score, entry.best_move))
+                } else {
+                    None
+                }
+            }
+            TTFlag::UpperBound => {
+                if entry.score <= alpha {
+                    Some((entry.score, entry.best_move))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// Get the best move from a previous search (for move ordering)
+    pub fn get_best_move(&self, hash: u64) -> Option<Move> {
+        let idx = self.index(hash);
+        let entry = &self.entries[idx];
+
+        if entry.hash == hash {
+            entry.best_move
+        } else {
+            None
+        }
+    }
+
+    /// Store a search result in the table
+    pub fn store(
+        &mut self,
+        hash: u64,
+        depth: u8,
+        score: i32,
+        flag: TTFlag,
+        best_move: Option<Move>,
+    ) {
+        let idx = self.index(hash);
+        let existing = &self.entries[idx];
+
+        // Replacement strategy: always replace if:
+        // 1. Empty entry
+        // 2. Same position with lower depth
+        // 3. Different position (collision)
+        if existing.hash != 0 && existing.hash != hash {
+            self.collisions += 1;
+        }
+
+        // Always replace for now (can add smarter replacement later)
+        self.entries[idx] = TTEntry {
+            hash,
+            depth,
+            score,
+            flag,
+            best_move,
+        };
+        self.stores += 1;
+    }
+
+    /// Clear all entries
+    pub fn clear(&mut self) {
+        for entry in &mut self.entries {
+            *entry = TTEntry::empty();
+        }
+        self.hits = 0;
+        self.stores = 0;
+        self.collisions = 0;
+    }
+
+    /// Get the fill rate (percentage of entries used)
+    pub fn fill_rate(&self) -> f64 {
+        let used = self.entries.iter().filter(|e| e.hash != 0).count();
+        (used as f64) / (self.entries.len() as f64) * 100.0
+    }
+
+    /// Get table size info
+    pub fn info(&self) -> String {
+        format!(
+            "TT: {} entries, {:.1}% filled, {} hits, {} stores, {} collisions",
+            self.entries.len(),
+            self.fill_rate(),
+            self.hits,
+            self.stores,
+            self.collisions
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Color, Piece, PieceType, Position, MoveFlag};
+
+    fn make_test_move() -> Move {
+        Move {
+            piece: Piece {
+                color: Color::White,
+                piece_type: PieceType::Pawn,
+                position: Position { rank: 2, file: 5 },
+            },
+            from: Position { rank: 2, file: 5 },
+            to: Position { rank: 4, file: 5 },
+            captured: None,
+            move_flag: MoveFlag::DoublePawnPush(Position { rank: 3, file: 5 }),
+        }
+    }
+
+    #[test]
+    fn test_tt_store_and_probe() {
+        let mut tt = TranspositionTable::new(1);
+        let hash = 0x123456789ABCDEF0u64;
+        let mv = make_test_move();
+
+        tt.store(hash, 4, 100, TTFlag::Exact, Some(mv));
+
+        // Should find it
+        let result = tt.probe(hash, 4, -1000, 1000);
+        assert!(result.is_some());
+        let (score, best_move) = result.unwrap();
+        assert_eq!(score, 100);
+        assert!(best_move.is_some());
+    }
+
+    #[test]
+    fn test_tt_depth_requirement() {
+        let mut tt = TranspositionTable::new(1);
+        let hash = 0x123456789ABCDEF0u64;
+
+        tt.store(hash, 3, 100, TTFlag::Exact, None);
+
+        // Should not find it at higher depth
+        assert!(tt.probe(hash, 4, -1000, 1000).is_none());
+
+        // Should find it at same or lower depth
+        assert!(tt.probe(hash, 3, -1000, 1000).is_some());
+        assert!(tt.probe(hash, 2, -1000, 1000).is_some());
+    }
+
+    #[test]
+    fn test_tt_lower_bound() {
+        let mut tt = TranspositionTable::new(1);
+        let hash = 0x123456789ABCDEF0u64;
+
+        tt.store(hash, 4, 100, TTFlag::LowerBound, None);
+
+        // Should return score if score >= beta
+        assert!(tt.probe(hash, 4, -1000, 50).is_some());
+        // Should not return if score < beta
+        assert!(tt.probe(hash, 4, -1000, 150).is_none());
+    }
+
+    #[test]
+    fn test_tt_upper_bound() {
+        let mut tt = TranspositionTable::new(1);
+        let hash = 0x123456789ABCDEF0u64;
+
+        tt.store(hash, 4, 100, TTFlag::UpperBound, None);
+
+        // Should return score if score <= alpha
+        assert!(tt.probe(hash, 4, 150, 1000).is_some());
+        // Should not return if score > alpha
+        assert!(tt.probe(hash, 4, 50, 1000).is_none());
+    }
+
+    #[test]
+    fn test_tt_clear() {
+        let mut tt = TranspositionTable::new(1);
+        let hash = 0x123456789ABCDEF0u64;
+
+        tt.store(hash, 4, 100, TTFlag::Exact, None);
+        assert!(tt.probe(hash, 4, -1000, 1000).is_some());
+
+        tt.clear();
+        assert!(tt.probe(hash, 4, -1000, 1000).is_none());
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -553,3 +553,38 @@ impl RaysForBoard {
 }
 
 // static RAYS_FOR_BOARD: RaysForBoard = RaysForBoard::new();
+
+/// Information needed to undo a move. Stored during make_move, used in unmake_move.
+#[derive(Debug, Clone)]
+pub struct UndoInfo {
+    /// The move that was made
+    pub mv: Move,
+    /// Previous castling rights
+    pub castle_kingside_white: bool,
+    pub castle_queenside_white: bool,
+    pub castle_kingside_black: bool,
+    pub castle_queenside_black: bool,
+    /// Previous en passant target
+    pub en_passant_target: Option<Position>,
+    /// Previous halfmove clock
+    pub halfmove_clock: u32,
+    /// The piece index in the pieces Vec that was moved
+    pub moved_piece_index: usize,
+    /// The index of the captured piece (if any) in the pieces Vec
+    pub captured_piece_index: Option<usize>,
+    /// Original piece type (for undoing promotion)
+    pub original_piece_type: PieceType,
+    /// For castling: the rook's index and original position
+    pub rook_info: Option<(usize, Position)>,
+    /// Previous Zobrist hash
+    pub zobrist_hash: u64,
+}
+
+/// Information needed to undo a null move (pass to opponent without moving)
+#[derive(Debug, Clone)]
+pub struct NullMoveUndo {
+    /// Previous en passant target
+    pub en_passant_target: Option<Position>,
+    /// Previous Zobrist hash
+    pub zobrist_hash: u64,
+}

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -1,0 +1,158 @@
+use crate::types::{Color, PieceType, Position};
+
+/// Zobrist hashing keys for chess positions.
+/// These are pseudo-random u64 values XORed together to create a unique hash for each position.
+pub struct ZobristKeys {
+    /// Keys for each (color, piece_type, square) combination: 2 * 6 * 64 = 768 keys
+    /// Indexed as: pieces[color][piece_type][square]
+    pub pieces: [[[u64; 64]; 6]; 2],
+    /// Key for side to move (XORed when it's black's turn)
+    pub side_to_move: u64,
+    /// Keys for castling rights (4 bits = 16 combinations, but we use 4 individual keys)
+    pub castle_kingside_white: u64,
+    pub castle_queenside_white: u64,
+    pub castle_kingside_black: u64,
+    pub castle_queenside_black: u64,
+    /// Keys for en passant file (0-7 for files a-h)
+    pub en_passant: [u64; 8],
+}
+
+impl ZobristKeys {
+    /// Initialize Zobrist keys with deterministic pseudo-random values.
+    /// Uses a simple PRNG seeded with a fixed value for reproducibility.
+    pub fn new() -> Self {
+        let mut rng = XorShift64::new(0x1234567890ABCDEF);
+
+        let mut pieces = [[[0u64; 64]; 6]; 2];
+        for color in 0..2 {
+            for piece in 0..6 {
+                for square in 0..64 {
+                    pieces[color][piece][square] = rng.next();
+                }
+            }
+        }
+
+        let side_to_move = rng.next();
+
+        let castle_kingside_white = rng.next();
+        let castle_queenside_white = rng.next();
+        let castle_kingside_black = rng.next();
+        let castle_queenside_black = rng.next();
+
+        let mut en_passant = [0u64; 8];
+        for file in 0..8 {
+            en_passant[file] = rng.next();
+        }
+
+        ZobristKeys {
+            pieces,
+            side_to_move,
+            castle_kingside_white,
+            castle_queenside_white,
+            castle_kingside_black,
+            castle_queenside_black,
+            en_passant,
+        }
+    }
+
+    /// Get the key for a piece at a position
+    #[inline]
+    pub fn piece_key(&self, color: Color, piece_type: PieceType, pos: &Position) -> u64 {
+        let color_idx = match color {
+            Color::White => 0,
+            Color::Black => 1,
+        };
+        let piece_idx = match piece_type {
+            PieceType::Pawn => 0,
+            PieceType::Knight => 1,
+            PieceType::Bishop => 2,
+            PieceType::Rook => 3,
+            PieceType::Queen => 4,
+            PieceType::King => 5,
+        };
+        let square_idx = ((pos.rank - 1) * 8 + (pos.file - 1)) as usize;
+        self.pieces[color_idx][piece_idx][square_idx]
+    }
+}
+
+/// Simple XorShift64 PRNG for deterministic key generation
+struct XorShift64 {
+    state: u64,
+}
+
+impl XorShift64 {
+    fn new(seed: u64) -> Self {
+        XorShift64 { state: seed }
+    }
+
+    fn next(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+}
+
+/// Global static Zobrist keys (initialized once)
+use once_cell::sync::Lazy;
+pub static ZOBRIST_KEYS: Lazy<ZobristKeys> = Lazy::new(|| ZobristKeys::new());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zobrist_keys_unique() {
+        let keys = ZobristKeys::new();
+
+        // Check that side_to_move key is non-zero
+        assert_ne!(keys.side_to_move, 0);
+
+        // Check that piece keys are unique
+        let mut all_keys: Vec<u64> = Vec::new();
+        for color in 0..2 {
+            for piece in 0..6 {
+                for square in 0..64 {
+                    all_keys.push(keys.pieces[color][piece][square]);
+                }
+            }
+        }
+        all_keys.push(keys.side_to_move);
+        all_keys.push(keys.castle_kingside_white);
+        all_keys.push(keys.castle_queenside_white);
+        all_keys.push(keys.castle_kingside_black);
+        all_keys.push(keys.castle_queenside_black);
+        for ep in &keys.en_passant {
+            all_keys.push(*ep);
+        }
+
+        // Check for uniqueness (no duplicates)
+        all_keys.sort();
+        for i in 1..all_keys.len() {
+            assert_ne!(all_keys[i - 1], all_keys[i], "Duplicate Zobrist key found");
+        }
+    }
+
+    #[test]
+    fn test_zobrist_deterministic() {
+        // Keys should be the same on repeated initialization
+        let keys1 = ZobristKeys::new();
+        let keys2 = ZobristKeys::new();
+
+        assert_eq!(keys1.side_to_move, keys2.side_to_move);
+        assert_eq!(keys1.castle_kingside_white, keys2.castle_kingside_white);
+
+        for color in 0..2 {
+            for piece in 0..6 {
+                for square in 0..64 {
+                    assert_eq!(
+                        keys1.pieces[color][piece][square],
+                        keys2.pieces[color][piece][square]
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements 10 search optimizations that enable the chess engine to search to depth 8 in reasonable time. Previously, even depth 4 with quiescence search would time out.

**Performance Results:**

| Depth | Before | After |
|-------|--------|-------|
| 4 | Timeout with quiescence | 273ms |
| 5 | N/A | 146ms |
| 6 | N/A | 258ms |
| 7 | N/A | 2.1s |
| 8 | N/A | 15.2s |

---

## Optimizations Implemented

### 1. Captures-Only Move Generation (`movegen.rs`)

**Problem:** Quiescence search was generating ALL legal moves and then filtering for captures, making it unusably slow.

**Solution:** Added `collect_captures()` method to `MoveGenerator` that only generates capture moves:
- Skips pawn pushes, only generates pawn captures and en passant
- For sliding pieces (bishop, rook, queen): only adds moves where target square is occupied by opponent
- For knights/king: same filter

**Impact:** Quiescence search now completes instead of timing out.

---

### 2. PST Bug Fix for Black Pieces (`evaluate.rs`)

**Problem:** Piece-Square Table (PST) indexing was incorrect for Black pieces, using `(rank-1)*8 + (file-1)` which doesn't mirror the board properly.

**Solution:** 
```rust
Color::White => (8 - piece.position.rank) * 8 + piece.position.file - 1,
Color::Black => (piece.position.rank - 1) * 8 + piece.position.file - 1,
```

This ensures Black's home rank (8) uses the same PST values as White's home rank (1), maintaining symmetry.

**Impact:** Black now plays correctly; starting position evaluates to 0.

---

### 3. Make/Unmake Move Pattern (`board.rs`, `types.rs`)

**Problem:** Every move in the search tree was cloning the entire board (Vec<Piece> + 8x8 array), causing massive allocations.

**Solution:** Implemented in-place mutation with undo capability:
- `make_move(&mut self, mv: &Move) -> UndoInfo` - Mutates board in place, returns info to restore
- `unmake_move(&mut self, undo: &UndoInfo)` - Restores board to previous state

`UndoInfo` stores:
- Previous castling rights (4 bools)
- Previous en passant target
- Previous halfmove clock
- Captured piece info
- Original piece type (for promotion undo)
- Rook movement info (for castling undo)
- Previous Zobrist hash

**Impact:** ~2-3x speedup from avoiding allocations.

---

### 4. MVV-LVA Move Ordering in Quiescence (`search.rs`)

**Problem:** Captures were searched in arbitrary order, missing easy alpha-beta cutoffs.

**Solution:** Sort captures by Most Valuable Victim - Least Valuable Attacker:
```rust
captures.sort_by_key(|m| {
    let victim = piece_value(m.captured.piece_type);
    let attacker = piece_value(m.piece.piece_type);
    -(victim * 10 - attacker)  // Queen captured by pawn = highest priority
});
```

**Impact:** More cutoffs in quiescence search, fewer nodes explored.

---

### 5. Zobrist Hashing (`zobrist.rs`, `board.rs`)

**Problem:** No efficient way to identify positions for transposition table.

**Solution:** Implemented Zobrist hashing with incrementally updated 64-bit hash:
- 768 random keys for (color, piece_type, square) combinations
- 4 keys for castling rights
- 8 keys for en passant file
- 1 key for side to move

Hash is XORed incrementally in `make_move`/`unmake_move`:
```rust
hash ^= piece_key(color, piece_type, from_square);
hash ^= piece_key(color, piece_type, to_square);
hash ^= side_to_move_key;
```

**Impact:** O(1) position identification for transposition table lookups.

---

### 6. Transposition Table (`tt.rs`, `search.rs`)

**Problem:** Same positions were being searched multiple times via different move orders.

**Solution:** Hash table storing search results:
```rust
pub struct TTEntry {
    hash: u64,           // Full hash for collision detection
    depth: u8,           // Search depth
    score: i32,          // Evaluation
    flag: TTFlag,        // Exact, LowerBound, or UpperBound
    best_move: Option<Move>,  // Best move found
}
```

On each search:
1. **Probe:** If position found with sufficient depth, return cached score
2. **Store:** After search, save result for future lookups
3. **Move ordering:** TT best move is searched first (priority 1,000,000)

**Impact:** ~2-3x speedup from avoiding redundant searches.

---

### 7. Iterative Deepening (`search.rs`)

**Problem:** Single deep search doesn't benefit from TT; move ordering is poor.

**Solution:** Search at depths 1, 2, 3, ... up to target depth:
```rust
for depth in 1..=max_depth {
    let result = negamax_with_tt(depth, board, alpha, beta, tt);
    best_result = Some(result);
}
```

**Benefits:**
- Each iteration populates TT with best moves
- Subsequent iterations use TT for perfect move ordering
- Can implement time controls (stop when time expires)

**Impact:** Depth 5 drops from 520ms (direct) to 146ms (iterative) - 3.5x faster.

---

### 8. Null Move Pruning (`search.rs`, `board.rs`)

**Problem:** Many positions can be quickly proven to be "too good" without full search.

**Solution:** Before searching moves, try a "null move" (passing turn to opponent):
```rust
if depth >= 3 && !in_check && beta < MAX_SCORE - 1000 {
    let undo = board.make_null_move();
    let score = -negamax(depth - 1 - R, board, -beta, -beta + 1, tt);
    board.unmake_null_move(&undo);
    
    if score >= beta {
        return beta;  // Opponent can't beat beta even with free move
    }
}
```

**How it works:** If giving the opponent a free move and they still can't beat beta, the position is so good we can prune it. Uses reduced depth (R=2) for the null move search.

**Safety conditions:**
- Not at shallow depth (depth >= 3)
- Not in check (null move would be illegal)
- Not near mate scores

**Impact:** Significant pruning of positions that are clearly winning.

---

### 9. Late Move Reductions (`search.rs`)

**Problem:** Later moves in a well-ordered list are unlikely to be best; searching them fully is wasteful.

**Solution:** Search later moves at reduced depth first:
```rust
if move_index >= 4 && depth >= 3 && !in_check && !is_capture {
    // Search with reduced depth (depth - 2)
    let score = -negamax(depth - 2, board, -alpha - 1, -alpha, tt);
    
    if score > alpha {
        // Surprised! Re-search at full depth
        score = -negamax(depth - 1, board, -beta, -alpha, tt);
    }
}
```

**How it works:** 
1. First 4 moves searched at full depth (likely best moves from TT/MVV-LVA)
2. Later moves searched at depth-2 with null window
3. If reduced search beats alpha, re-search at full depth

**Conditions:**
- Not first 4 moves
- Sufficient depth (>= 3)
- Not in check
- Not a capture (captures are tactical, don't reduce)

**Impact:** Depth 6 drops from 1.55s to 258ms - 6x faster.

---

## New Files

- **`src/zobrist.rs`** - Zobrist key generation and global keys
- **`src/tt.rs`** - Transposition table implementation
- **`src/bin/profile.rs`** - Performance benchmarking binary

## Test Plan

- [x] All existing tests pass (`cargo test --lib -- --skip stockfish --skip perft`)
- [x] Zobrist hash tests verify uniqueness and determinism
- [x] Make/unmake tests verify board state restoration
- [x] TT tests verify probe/store behavior
- [x] PST tests verify symmetric evaluation
- [x] Profile binary shows expected performance improvements