### PR TITLE
Add security hardening for production deployment

### DIFF
--- a/web-app/src/lib/useChessGame.ts
+++ b/web-app/src/lib/useChessGame.ts
@@ -22,7 +22,7 @@ const initialState: ChessGameState = {
   gameId: null,
   board: null,
   playerColor: 'white',
-  depth: 4,
+  depth: 5, // Expert difficulty
   isFlipped: false,
   selectedSquare: null,
   lastMove: null,


### PR DESCRIPTION
## Summary
- Use cryptographically random game IDs (128-bit) instead of predictable timestamps
- Cap engine depth at 8 to prevent CPU exhaustion attacks
- Default to Expert difficulty (depth 5) for better user experience  
- Restrict CORS to same-origin only (Traefik handles cross-origin requests)
- Handle RwLock poisoning gracefully to prevent server panics

## Test plan
- [ ] Start new game and verify random game ID format (32 hex chars)
- [ ] Attempt to set depth > 8 via API and verify it's capped
- [ ] Verify default difficulty is Expert (depth 5) in UI
- [ ] Test that CORS blocks cross-origin requests when not behind Traefik
- [ ] Build and deploy Docker image